### PR TITLE
Fix Mass Edit Terms pagination by restoring paged query argument

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -495,9 +495,45 @@ body.taxopress_page_st_terms tr.inline-edit-row td {
 .st_wrap.st_mass_terms-page .box-selector-taxonomy {
     margin: 0;
     padding: 0;
-    background: aliceblue;
-    color: transparent;
+    width: auto;
+    max-width: none;
+    border: 0;
+    background: transparent;
+    color: inherit;
     display: inline-block;
+}
+
+.st_wrap.st_mass_terms-page .custom-nav {
+    height: auto;
+    min-height: 30px;
+}
+
+.st_wrap.st_mass_terms-page .custom-nav .tablenav-pages {
+    margin: 0 0 12px;
+}
+
+.st_wrap.st_mass_terms-page .custom-nav > div:not(.tablenav-pages),
+.st_wrap.st_mass_terms-page .box-selector-taxonomy .change-taxo,
+.st_wrap.st_mass_terms-page .box-selector-taxonomy .change-taxo form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.st_wrap.st_mass_terms-page .custom-nav > div:not(.tablenav-pages) {
+    clear: both;
+    float: none !important;
+}
+
+.st_wrap.st_mass_terms-page #post-query-submit,
+.st_wrap.st_mass_terms-page .box-selector-taxonomy .change-taxo select,
+.st_wrap.st_mass_terms-page .box-selector-taxonomy .change-taxo input[type=submit] {
+    min-height: 30px;
+    height: 30px;
+    margin: 0;
+    padding: 0 10px;
+    line-height: 28px;
 }
 
 .box-selector-taxonomy .change-taxo select,

--- a/inc/class.admin.mass.php
+++ b/inc/class.admin.mass.php
@@ -431,6 +431,9 @@ class SimpleTags_Admin_Mass
             $q['posts_per_page'] = 15;
         }
 
+        // Pagination
+        $q['paged'] = isset($q['paged']) ? max(1, (int) $q['paged']) : 1;
+
         // Content type
         $q['post_type'] = SimpleTags_Admin::$post_type;
 
@@ -500,6 +503,7 @@ class SimpleTags_Admin_Mass
             'post_type'      => $q['post_type'],
             'what_to_show'   => 'posts',
             'posts_per_page' => $q['posts_per_page'],
+            'paged'          => $q['paged'],
             'order'          => $order,
             'orderby'        => $orderby,
         );


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
Sanitize the requested page number and pass it to WP_Query so numbered, next, and previous pagination links load the correct posts while preserving term filters and other query parameters.

## Benefits
fixed #3014 

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#3014 
## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
