### PR TITLE
Add per-post Auto Terms toggles

### DIFF
--- a/inc/class.admin.post.php
+++ b/inc/class.admin.post.php
@@ -4,6 +4,10 @@
 
 class SimpleTags_Admin_Post_Settings
 {
+    private const STATUS_DEFAULT = 'default';
+    private const STATUS_ENABLED = 'enabled';
+    private const STATUS_DISABLED = 'disabled';
+
     /**
      * Constructor
      *
@@ -60,19 +64,27 @@ class SimpleTags_Admin_Post_Settings
             return;
         }
 
+        wp_nonce_field('taxopress_post_settings', 'taxopress_post_settings_nonce');
+
         // Auto terms for this CPT ?
         if (1 === (int) SimpleTags_Plugin::get_option_value('active_auto_terms')) {
-            $meta_value = get_post_meta($post->ID, '_exclude_autotags', true);
+            $meta_value = self::get_status($post->ID, '_taxopress_autoterms_status', '_exclude_autotags');
             echo '<p>' . "\n";
-            echo '<label><input type="checkbox" name="exclude_autotags" value="true" ' . checked(esc_attr($meta_value), true, false) . ' /> ' . esc_html__('Disable Auto Terms', 'simple-tags') . '</label><br />' . "\n";
+            echo '<label for="taxopress_autoterms_status">' . esc_html__('Auto Terms', 'simple-tags') . '</label><br />' . "\n";
+            echo '<select id="taxopress_autoterms_status" name="taxopress_autoterms_status">' . "\n";
+            self::status_options($meta_value);
+            echo '</select>' . "\n";
             echo '</p>' . "\n";
             echo '<input type="hidden" name="_meta_autotags" value="true" />';
         }
 
         if (1 === (int) SimpleTags_Plugin::get_option_value('active_auto_links')) {
-            $meta_value = get_post_meta($post->ID, '_exclude_autolinks', true);
+            $meta_value = self::get_status($post->ID, '_taxopress_autolinks_status', '_exclude_autolinks');
             echo '<p>' . "\n";
-            echo '<label><input type="checkbox" name="exclude_autolinks" value="true" ' . checked(esc_attr($meta_value), true, false) . ' /> ' . esc_html__('Disable Auto Links', 'simple-tags') . '</label><br />' . "\n";
+            echo '<label for="taxopress_autolinks_status">' . esc_html__('Auto Links', 'simple-tags') . '</label><br />' . "\n";
+            echo '<select id="taxopress_autolinks_status" name="taxopress_autolinks_status">' . "\n";
+            self::status_options($meta_value);
+            echo '</select>' . "\n";
             echo '</p>' . "\n";
             echo '<input type="hidden" name="_meta_autolink" value="true" />';
         }
@@ -88,20 +100,89 @@ class SimpleTags_Admin_Post_Settings
      */
     public static function save_post($object_id = 0)
     {
-        if (isset($_POST['_meta_autotags']) && 'true' === $_POST['_meta_autotags']) {
-            if (isset($_POST['exclude_autotags'])) {
-                update_post_meta($object_id, '_exclude_autotags', true);
-            } else {
-                delete_post_meta($object_id, '_exclude_autotags');
-            }
+        if (
+            ! isset($_POST['taxopress_post_settings_nonce'])
+            || ! wp_verify_nonce(
+                sanitize_text_field(wp_unslash($_POST['taxopress_post_settings_nonce'])),
+                'taxopress_post_settings'
+            )
+        ) {
+            return;
         }
 
-        if (isset($_POST['_meta_autolink']) && 'true' === $_POST['_meta_autolink']) {
-            if (isset($_POST['exclude_autolinks'])) {
-                update_post_meta($object_id, '_exclude_autolinks', true);
+        if ((defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) || wp_is_post_revision($object_id)) {
+            return;
+        }
+
+        if (! current_user_can('edit_post', $object_id)) {
+            return;
+        }
+
+        $has_autotags_meta = isset($_POST['_meta_autotags']) && 'true' === sanitize_text_field(wp_unslash($_POST['_meta_autotags']));
+        $has_autolink_meta = isset($_POST['_meta_autolink']) && 'true' === sanitize_text_field(wp_unslash($_POST['_meta_autolink']));
+
+        if ($has_autotags_meta) {
+            self::save_status($object_id, 'taxopress_autoterms_status', '_taxopress_autoterms_status', '_exclude_autotags');
+        }
+
+        if ($has_autolink_meta) {
+            self::save_status($object_id, 'taxopress_autolinks_status', '_taxopress_autolinks_status', '_exclude_autolinks');
+        }
+    }
+
+    private static function get_status($post_id, $status_meta_key, $legacy_disable_meta_key = '')
+    {
+        $status = get_post_meta($post_id, $status_meta_key, true);
+
+        if (self::is_valid_status($status)) {
+            return $status;
+        }
+
+        if ($legacy_disable_meta_key && get_post_meta($post_id, $legacy_disable_meta_key, true)) {
+            return self::STATUS_DISABLED;
+        }
+
+        return self::STATUS_DEFAULT;
+    }
+
+    private static function save_status($post_id, $post_key, $status_meta_key, $legacy_disable_meta_key = '')
+    {
+        $status = isset($_POST[$post_key]) ? sanitize_key(wp_unslash($_POST[$post_key])) : self::STATUS_DEFAULT;
+
+        if (! self::is_valid_status($status)) {
+            $status = self::STATUS_DEFAULT;
+        }
+
+        if (self::STATUS_DEFAULT === $status) {
+            delete_post_meta($post_id, $status_meta_key);
+        } else {
+            update_post_meta($post_id, $status_meta_key, $status);
+        }
+
+        if ($legacy_disable_meta_key) {
+            if (self::STATUS_DISABLED === $status) {
+                update_post_meta($post_id, $legacy_disable_meta_key, true);
             } else {
-                delete_post_meta($object_id, '_exclude_autolinks');
+                delete_post_meta($post_id, $legacy_disable_meta_key);
             }
         }
+    }
+
+    private static function status_options($current_status)
+    {
+        $statuses = [
+            self::STATUS_DEFAULT  => esc_html__('Default', 'simple-tags'),
+            self::STATUS_ENABLED  => esc_html__('Enable', 'simple-tags'),
+            self::STATUS_DISABLED => esc_html__('Disable', 'simple-tags'),
+        ];
+
+        foreach ($statuses as $status => $label) {
+            echo '<option value="' . esc_attr($status) . '"' . selected($current_status, $status, false) . '>' . esc_html($label) . '</option>' . "\n";
+        }
+    }
+
+    private static function is_valid_status($status)
+    {
+        return in_array($status, [self::STATUS_DEFAULT, self::STATUS_ENABLED, self::STATUS_DISABLED], true);
     }
 }

--- a/inc/class.client.autolinks.php
+++ b/inc/class.client.autolinks.php
@@ -974,8 +974,7 @@ class SimpleTags_Client_Autolinks
         $post_tags = taxopress_get_autolink_data();
 
         // user preference for this post ?
-        $meta_value = get_post_meta($post->ID, '_exclude_autolinks', true);
-        if (!empty($meta_value)) {
+        if ('disabled' === self::get_post_feature_status($post->ID)) {
             return $content;
         }
 
@@ -1093,8 +1092,7 @@ class SimpleTags_Client_Autolinks
 
 
         // user preference for this post ?
-        $meta_value = get_post_meta($post->ID, '_exclude_autolinks', true);
-        if (!empty($meta_value)) {
+        if ('disabled' === self::get_post_feature_status($post->ID)) {
             return $title;
         }
 
@@ -1188,5 +1186,20 @@ class SimpleTags_Client_Autolinks
 
 
         return $title;
+    }
+
+    private static function get_post_feature_status($post_id)
+    {
+        $status = get_post_meta($post_id, '_taxopress_autolinks_status', true);
+
+        if (in_array($status, ['default', 'enabled', 'disabled'], true)) {
+            return $status;
+        }
+
+        if (get_post_meta($post_id, '_exclude_autolinks', true)) {
+            return 'disabled';
+        }
+
+        return 'default';
     }
 }

--- a/inc/class.client.autolinks.php
+++ b/inc/class.client.autolinks.php
@@ -17,26 +17,20 @@ class SimpleTags_Client_Autolinks
     public function __construct()
     {
 
+        // Register frontend filters regardless of the global setting so a post-level
+        // "enabled" status can force Auto Links on.
+        add_filter('the_posts', array(__CLASS__, 'the_posts'), 10);
+        add_filter('the_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
+        add_filter('the_title', array(__CLASS__, 'taxopress_autolinks_the_title'), 5);
+
+        // Elementor compatibility: elementor outputs content through its own filters,
+        // so also run our autolinks on those outputs.
+        if (defined('ELEMENTOR_VERSION') || class_exists('\Elementor\Plugin')) {
+            add_filter('elementor/frontend/the_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
+            add_filter('elementor/frontend/builder_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
+        }
+
         if (1 === (int) SimpleTags_Plugin::get_option_value('active_auto_links')) {
-            $auto_link_priority = SimpleTags_Plugin::get_option_value('auto_link_priority');
-            if (0 === (int) $auto_link_priority) {
-                $auto_link_priority = 12;
-            }
-
-            // Auto link tags
-            add_filter('the_posts', array(__CLASS__, 'the_posts'), 10);
-
-            //new UI
-            add_filter('the_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
-            add_filter('the_title', array(__CLASS__, 'taxopress_autolinks_the_title'), 5);
-
-            // Elementor compatibility: elementor outputs content through its own filters,
-            // so also run our autolinks on those outputs.
-            if (defined('ELEMENTOR_VERSION') || class_exists('\Elementor\Plugin')) {
-                add_filter('elementor/frontend/the_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
-                add_filter('elementor/frontend/builder_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
-            }
-
             add_action('admin_init', [$this, 'taxopress_customurl_taxonomies_fields']);
         }
     }
@@ -973,10 +967,16 @@ class SimpleTags_Client_Autolinks
 
         $post_tags = taxopress_get_autolink_data();
 
-        // user preference for this post ?
-        if ('disabled' === self::get_post_feature_status($post->ID)) {
+        // User preference for this post?
+        $feature_status = self::get_post_feature_status($post->ID);
+        if (
+            'disabled' === $feature_status
+            || ('default' === $feature_status && 1 !== (int) SimpleTags_Plugin::get_option_value('active_auto_links'))
+        ) {
             return $content;
         }
+
+        $force_enabled = 'enabled' === $feature_status;
 
         if (count($post_tags) > 0) {
             $auto_link_replace = [];
@@ -984,11 +984,7 @@ class SimpleTags_Client_Autolinks
                 // Get option
                 $embedded = (isset($post_tag['embedded']) && is_array($post_tag['embedded']) && count($post_tag['embedded']) > 0) ? $post_tag['embedded'] : false;
 
-                if (!$embedded) {
-                    continue;
-                }
-
-                if (!in_array($post->post_type, $embedded)) {
+                if (!$force_enabled && (!$embedded || !in_array($post->post_type, $embedded, true))) {
                     continue;
                 }
 
@@ -1091,21 +1087,23 @@ class SimpleTags_Client_Autolinks
         $post_tags = taxopress_get_autolink_data();
 
 
-        // user preference for this post ?
-        if ('disabled' === self::get_post_feature_status($post->ID)) {
+        // User preference for this post?
+        $feature_status = self::get_post_feature_status($post->ID);
+        if (
+            'disabled' === $feature_status
+            || ('default' === $feature_status && 1 !== (int) SimpleTags_Plugin::get_option_value('active_auto_links'))
+        ) {
             return $title;
         }
+
+        $force_enabled = 'enabled' === $feature_status;
 
         if (count($post_tags) > 0) {
             foreach ($post_tags as $post_tag) {
                 // Get option
                 $embedded = (isset($post_tag['embedded']) && is_array($post_tag['embedded']) && count($post_tag['embedded']) > 0) ? $post_tag['embedded'] : false;
 
-                if (!$embedded) {
-                    continue;
-                }
-
-                if (!in_array($post->post_type, $embedded)) {
+                if (!$force_enabled && (!$embedded || !in_array($post->post_type, $embedded, true))) {
                     continue;
                 }
 

--- a/inc/class.client.autoterms.php
+++ b/inc/class.client.autoterms.php
@@ -33,8 +33,8 @@ class SimpleTags_Client_Autoterms
         $options = get_option(STAGS_OPTIONS_NAME_AUTO);
 
         // user preference for this post ?
-        $meta_value = isset($_POST['exclude_autotags']) ? sanitize_text_field(wp_unslash($_POST['exclude_autotags'])) : false;
-        if ($meta_value) {
+        $post_autoterms_status = self::get_post_feature_status($post_id, '_taxopress_autoterms_status', '_exclude_autotags');
+        if ('disabled' === $post_autoterms_status) {
             return false;
         }
 
@@ -67,7 +67,7 @@ class SimpleTags_Client_Autoterms
                 continue;
             }
             // check if auto term is enabled for post
-            if (empty($autoterm_data['autoterm_for_post'])) {
+            if (empty($autoterm_data['autoterm_for_post']) && 'enabled' !== $post_autoterms_status) {
                 continue;
             }
 
@@ -184,8 +184,7 @@ class SimpleTags_Client_Autoterms
 
         $terms_to_add = array();
 
-        $exclude_autotags = get_post_meta($object->ID, '_exclude_autotags', true);
-        if ($exclude_autotags) {
+        if ('disabled' === self::get_post_feature_status($object->ID, '_taxopress_autoterms_status', '_exclude_autotags')) {
             $empty_term_messages[$object->ID]['message'][] = esc_html__('Post is excluded from Auto Term from post area.', 'simple-tags');
             return false;
         }
@@ -998,7 +997,6 @@ class SimpleTags_Client_Autoterms
      */
     public static function update_taxopress_logs($object, $taxonomy = 'post_tag', $options = array(), $counter = false, $action = 'save_posts', $component = 'st_autoterms', $terms_to_add = [], $status = 'failed', $status_message = 'not_provided')
     {
-
         if (get_option('taxopress_autoterms_logs_disabled') || !post_type_exists('taxopress_logs')) {
             return;
         }
@@ -1045,5 +1043,20 @@ class SimpleTags_Client_Autoterms
                 }
             }
         }
+    }
+
+    private static function get_post_feature_status($post_id, $status_meta_key, $legacy_disable_meta_key = '')
+    {
+        $status = get_post_meta($post_id, $status_meta_key, true);
+
+        if (in_array($status, ['default', 'enabled', 'disabled'], true)) {
+            return $status;
+        }
+
+        if ($legacy_disable_meta_key && get_post_meta($post_id, $legacy_disable_meta_key, true)) {
+            return 'disabled';
+        }
+
+        return 'default';
     }
 }


### PR DESCRIPTION
## Summary
- replace the old per-post disable checkboxes with Default / Enable / Disable selects
- add per-post controls for Auto Terms and Auto Links
- keep legacy `_exclude_autotags` and `_exclude_autolinks` meta behavior compatible

## Details
The post editor metabox can now override behavior per post:
- Default follows the configured Auto Terms / Auto Links settings.
- Enable forces Auto Terms to run on save even when the matching Auto Terms setting is not enabled for post-save.
- Disable skips Auto Terms / Auto Links for that post.

Fixes #3006.

## Testing
- php -l inc/class.admin.post.php
- php -l inc/class.client.autoterms.php
- php -l inc/class.client.autolinks.php
- git diff --check